### PR TITLE
Add dashboard/back button to navigate the dashboard from the timer page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -756,3 +756,34 @@ header {
 @keyframes confettiFall {
   to { transform: translateY(110vh) rotate(720deg); opacity: 0; }
 }
+/* ===== BACK TO DASHBOARD BUTTON ===== */
+.btn-back {
+  position: absolute;
+  top: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 18px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  backdrop-filter: blur(10px);
+  color: var(--muted);
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  z-index: 5;
+}
+
+.btn-back:hover {
+  border-color: var(--accent);
+  color: var(--text);
+  box-shadow: 0 0 18px var(--glow);
+  transform: translateX(-50%) translateY(-2px);
+}
+
+.btn-back:active {
+  transform: translateX(-50%) scale(0.95);
+}

--- a/index.html
+++ b/index.html
@@ -73,6 +73,12 @@
   </div>
 
   <div class="timer-container">
+
+    <!-- ===== BACK BUTTON ADDED HERE ===== -->
+    <button class="btn-back" id="btn-back" title="Back to Dashboard">
+      ← Dashboard
+    </button>
+
     <div class="ring-glow" id="ring-glow"></div>
     <svg class="ring-svg" id="ring-svg" viewBox="0 0 320 320">
       <circle class="ring-track" cx="160" cy="160" r="148"/>
@@ -150,7 +156,7 @@
         <div class="receipt-date" id="receipt-date"></div>
       </div>
       <div class="receipt-body" id="receipt-body"></div>
-      <button class="receipt-close" id="receipt-close">Close &amp; Keep Grinding</button>
+      <button class="receipt-close" id="receipt-close">Close & Keep Grinding</button>
       <div class="receipt-footer">
         <div class="receipt-barcode" id="receipt-barcode"></div>
         THANK YOU · COME AGAIN · OR DON'T<br>NO REFUNDS ON LOST TIME

--- a/js/timer.js
+++ b/js/timer.js
@@ -718,6 +718,28 @@ document.getElementById('theme-toggle').addEventListener('click', () => {
 document.getElementById('receipt-close').addEventListener('click', () => {
   document.getElementById('receipt-overlay').classList.remove('open');
 });
+// ==================== BACK TO DASHBOARD ====================
+document.getElementById('btn-back').addEventListener('click', () => {
+  if (soundEnabled) playClick();
+
+  // Pause timer if running
+  if (running) pause();
+
+  // Close receipt if open
+  document.getElementById('receipt-overlay').classList.remove('open');
+
+  // Hide main app
+  document.getElementById('app').classList.remove('visible');
+
+  // Show onboarding screen
+  const ob = document.getElementById('onboarding');
+  ob.style.display = 'flex';
+  ob.style.opacity = '1';
+  ob.style.transform = 'scale(1)';
+  ob.style.pointerEvents = 'all';
+
+  showNotif('Returned to dashboard.');
+});
 
 // Receipt button — generate anytime
 document.getElementById('btn-receipt').addEventListener('click', () => {


### PR DESCRIPTION
📌 Description

Adds a Back to Dashboard button to the timer screen that allows users to return to the onboarding dashboard without refreshing the page. The button pauses the timer (if running), closes the receipt overlay (if open), and restores the onboarding view.

🔗 Related Issue

Closes #8

🛠 Changes Made

Added btn-back button inside .timer-container

Styled the button in style.css to match the glass UI theme

Added event listener in timer.js

Ensured timer pauses before returning to dashboard

Ensured receipt overlay closes when navigating back

Added notification feedback when returning

📷 Screenshots (if applicable)



✅ Checklist

 I have tested my changes

 My code follows project guidelines

 I have linked the related issue

If you want a more professional / open-source style PR description (like for GitHub portfolio), I can rewrite it in a stronger technical tone.