### PR TITLE
Add Custom Timer Duration Settings for Focus and Break Sessions

### DIFF
--- a/js/timer.js
+++ b/js/timer.js
@@ -152,7 +152,12 @@ const MODE_LABELS = {
 
 // ==================== STATE ====================
 let personality    = 'asian-mom';
-let settings       = { work: 25, short: 5, long: 15 };
+// ✅ Load saved settings or use default
+let settings = {
+  work: parseInt(localStorage.getItem('gr-work')) || 25,
+  short: parseInt(localStorage.getItem('gr-short')) || 5,
+  long: parseInt(localStorage.getItem('gr-long')) || 15
+};
 let timerMode      = 'work';
 let totalSeconds   = settings.work * 60;
 let remaining      = totalSeconds;
@@ -848,16 +853,35 @@ document.querySelectorAll('.tab').forEach(tab => {
 
 document.querySelectorAll('.sctrl').forEach(btn => {
   btn.addEventListener('click', () => {
+
     const s   = btn.dataset.setting;
     const dir = parseInt(btn.dataset.dir);
     const max = s === 'work' ? 60 : 30;
+
     settings[s] = Math.min(max, Math.max(1, settings[s] + dir));
+
+    // ✅ SAVE TO LOCAL STORAGE
+    localStorage.setItem('gr-work', settings.work);
+    localStorage.setItem('gr-short', settings.short);
+    localStorage.setItem('gr-long', settings.long);
+
     document.getElementById(`sval-${s}`).textContent = settings[s];
+
     if (s === timerMode) {
+
       totalSeconds = settings[s] * 60;
-      if (!running) { remaining = totalSeconds; updateDisplay(); }
+
+      if (!running) {
+
+        remaining = totalSeconds;
+        updateDisplay();
+
+      }
+
     }
+
     if (soundEnabled) playClick();
+
   });
 });
 
@@ -937,5 +961,11 @@ try {
 
 applyAccent('work');
 applyPersonality(personality);
+
+// ✅ Display saved settings
+document.getElementById('sval-work').textContent = settings.work;
+document.getElementById('sval-short').textContent = settings.short;
+document.getElementById('sval-long').textContent = settings.long;
+
 updateDisplay();
 updateSessionDots();


### PR DESCRIPTION
## 📌 Description

This PR adds a customizable timer duration feature that allows users to adjust focus, short break, and long break durations according to their preference.

The selected durations are now saved in localStorage, so the values persist even after refreshing or reopening the application.

---

## 🔗 Related Issue

Closes: #18 
---

## 🛠 Changes Made

- Enabled customization of focus, short break, and long break durations
- Saved timer settings in localStorage
- Loaded saved settings automatically when the app starts
- Updated timer dynamically based on user settings

---

## 📷 Screenshots

Screenshot showing changed timer duration and persistence after refresh.
<img width="1873" height="892" alt="image" src="https://github.com/user-attachments/assets/7822b4a9-3ad2-4842-ac03-ed1edb0ff8c3" />

---

## ✅ Checklist

- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue