### PR TITLE
Changed down panel font color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,7 +10,7 @@
   --surface:          rgba(255,255,255,0.03);
   --border:           rgba(255,255,255,0.07);
   --text:             #e8e9f5;
-  --muted:            rgba(232,233,245,0.4);
+  --muted:            rgb(255, 255, 255);
   --ring-track:       rgba(255,255,255,0.06);
   --sdot-bg:          rgba(255,255,255,0.12);
   --sdot-border:      rgba(255,255,255,0.10);
@@ -26,7 +26,7 @@
   --surface:          rgba(0,0,0,0.04);
   --border:           rgba(0,0,0,0.10);
   --text:             #1a1820;
-  --muted:            rgba(26,24,32,0.45);
+  --muted:            rgba(1, 0, 8, 0.904);
   --ring-track:       rgba(0,0,0,0.07);
   --sdot-bg:          rgba(0,0,0,0.10);
   --sdot-border:      rgba(0,0,0,0.08);


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
Changed the down panel which said foccus,short,long font-color which was dull to more darker font for visibility

## 🔗 Related Issue
Closes #23

## 🛠 Changes Made
- Made a darker font to the down panel
- for both in light and dark mode

---

## 📷 Screenshots (if applicable)
-before
:dark mode
<img width="719" height="26" alt="image" src="https://github.com/user-attachments/assets/9e38c852-4f24-4ddd-9e6a-16cd8a86bc63" />

:light mode
<img width="715" height="28" alt="image" src="https://github.com/user-attachments/assets/b11c2357-1170-44d6-9859-3b0219b1506d" />


after
:dark mode
<img width="713" height="34" alt="image" src="https://github.com/user-attachments/assets/87a17725-cd12-4bc5-9c0e-bd95790f11d4" />

:light mode
<img width="712" height="26" alt="image" src="https://github.com/user-attachments/assets/2d9518e5-3b93-4f4e-9efd-1a76ebd58d11" />
