### PR TITLE
Add persistent mute/unmute toggle for Pomodoro sound notifications

### DIFF
--- a/js/timer.js
+++ b/js/timer.js
@@ -165,7 +165,7 @@ let running        = false;
 let interval       = null;
 let session        = 1;
 let completedWork  = 0;
-let soundEnabled   = true;
+let soundEnabled = localStorage.getItem("gr-sound") !== "false";
 let isDark         = true;
 let tickerInterval = null;
 let notifInterval  = null;
@@ -885,11 +885,19 @@ document.querySelectorAll('.sctrl').forEach(btn => {
   });
 });
 
-document.getElementById('sound-toggle').addEventListener('click', () => {
+ const soundToggle = document.getElementById('sound-toggle');
+
+// set icon based on saved preference
+soundToggle.textContent = soundEnabled ? '🔔' : '🔕';
+soundToggle.classList.toggle('active', soundEnabled);
+
+soundToggle.addEventListener('click', () => {
   soundEnabled = !soundEnabled;
-  const el = document.getElementById('sound-toggle');
-  el.textContent = soundEnabled ? '\uD83D\uDD14' : '\uD83D\uDD15';
-  el.classList.toggle('active', soundEnabled);
+
+  soundToggle.textContent = soundEnabled ? '🔔' : '🔕';
+  soundToggle.classList.toggle('active', soundEnabled);
+
+  localStorage.setItem("gr-sound", soundEnabled);
 });
 
 document.getElementById('theme-toggle').addEventListener('click', () => {


### PR DESCRIPTION
## 📌 Description
Adds a mute/unmute toggle option for the Pomodoro timer sound notifications.

Users can now enable or disable sound alerts using the sound toggle button. 
The preference is stored using localStorage so the selected setting persists even after refreshing the page.
## 🔗 Related Issue
Closes #32

---

## 🛠 Changes Made
- - Added mute/unmute toggle functionality for timer sound
- Stored sound preference using localStorage
- Updated sound toggle button to reflect current state (🔔 / 🔕)
- Ensured sound settings persist after page refresh



## ✅ Checklist
- [x ] I have tested my changes
- [ x] My code follows project guidelines
- [ x] I have linked the related issue
